### PR TITLE
PAL60 VI Mode, Region Free ROM Header

### DIFF
--- a/include/variables.h
+++ b/include/variables.h
@@ -37,6 +37,7 @@ extern OSViMode osViModeMpalLan1;
 extern OSViContext* __osViCurr;
 extern OSViContext* __osViNext;
 extern OSViMode osViModeFpalLan1;
+extern OSViMode gCustomViModePal60Lan1;
 extern u32 __additional_scanline;
 extern const char gBuildMakeOption[];
 extern const char gBuildGitVersion[];

--- a/spec
+++ b/spec
@@ -17,6 +17,7 @@ beginseg
     include "$(BUILD_DIR)/src/boot/boot_main.o"
     include "$(BUILD_DIR)/data/unk_800093F0.data.o"
     include "$(BUILD_DIR)/data/unk_80009410.data.o"
+    include "$(BUILD_DIR)/src/boot/vimodepal60lan1.o"
     include "$(BUILD_DIR)/src/boot/idle.o"
     include "$(BUILD_DIR)/src/boot/viconfig.o"
     include "$(BUILD_DIR)/src/boot/z_std_dma.o"

--- a/src/boot/idle.c
+++ b/src/boot/idle.c
@@ -57,9 +57,13 @@ void Idle_ThreadEntry(void* arg) {
 
     switch (osTvType) {
         case OS_TV_NTSC:
-        case OS_TV_PAL:
             gViConfigModeType = OS_VI_NTSC_LAN1;
             gViConfigMode = osViModeNtscLan1;
+            break;
+
+        case OS_TV_PAL:
+            gViConfigModeType = OS_VI_FPAL_LAN1;
+            gViConfigMode = gCustomViModePal60Lan1;
             break;
 
         case OS_TV_MPAL:

--- a/src/boot/viconfig.c
+++ b/src/boot/viconfig.c
@@ -10,6 +10,9 @@ void ViConfig_UpdateVi(u32 black) {
 
         PRINTF(VT_COL(YELLOW, BLACK) "osViSetYScale1(%f);\n" VT_RST, 1.0f);
 
+        if (osTvType == OS_TV_PAL) {
+            osViSetMode(&osViModePalLan1);
+        }
 
         // Reset the VI y scale. The VI y scale is different between NTSC (1.0) and PAL (0.833)
         // and should be reset to 1.0 during PreNMI to ensure there are no issues when restarting.

--- a/src/boot/vimodepal60lan1.c
+++ b/src/boot/vimodepal60lan1.c
@@ -1,0 +1,56 @@
+/**
+ * @file vimodepal60lan1.c
+ *
+ * PAL60 LAN1 Video Mode
+ *
+ * L = Low Resolution
+ * A = Anti-Aliased
+ * N = Deinterlaced
+ * 1 = 16-bit Framebuffer
+ */
+#include "global.h"
+#include "ultra64/viint.h"
+
+/*
+ * Based on FPAL LAN1 but with (approximately) NTSC VSYNC and NTSC VSTART.
+ * This mode may behave poorly on emulators (e.g. an emulator may refresh at only 50Hz);
+ * in that case just use an NTSC mode instead, such an emulator surely doesn't care about the differences.
+ */
+OSViMode gCustomViModePal60Lan1 = {
+    OS_VI_FPAL_LAN1, // type
+    {
+        // comRegs
+        VI_CTRL_TYPE_16 | VI_CTRL_GAMMA_DITHER_ON | VI_CTRL_GAMMA_ON | VI_CTRL_DIVOT_ON | VI_CTRL_ANTIALIAS_MODE_1 |
+            VI_CTRL_PIXEL_ADV(3), // ctrl
+        WIDTH(320),               // width
+        BURST(58, 30, 4, 69),     // burst
+        // Ideally VSYNC would be 525 but this produces marginally-too-slow retraces. 519 is the closest value that
+        // produces an ~16.6ms retrace (specifically about 16.70ms). We expect 519 to be OK compatibility-wise, it's
+        // within 1.5% of the nominal value.
+        VSYNC(519),               // vSync
+        // We could also have modified HSYNC to correct the retrace timings, however in general HSYNC is more sensitive
+        // than VSYNC so we choose to leave HSYNC at the nominal value.
+        HSYNC(3177, 23),          // hSync
+        LEAP(3183, 3181),         // leap
+        HSTART(128, 768),         // hStart
+        SCALE(2, 0),              // xScale
+        VCURRENT(0),              // vCurrent
+    },
+    { // fldRegs
+      {
+          // [0]
+          ORIGIN(640),         // origin
+          SCALE(1, 0),         // yScale
+          START(37, 511),      // vStart
+          BURST(107, 2, 9, 0), // vBurst
+          VINTR(2),            // vIntr
+      },
+      {
+          // [1]
+          ORIGIN(640),         // origin
+          SCALE(1, 0),         // yScale
+          START(37, 511),      // vStart
+          BURST(107, 2, 9, 0), // vBurst
+          VINTR(2),            // vIntr
+      } },
+};

--- a/src/boot/z_locale.c
+++ b/src/boot/z_locale.c
@@ -8,6 +8,24 @@ void Locale_Init(void) {
     osEPiReadIo(gCartHandle, 0x38, &sCartInfo.mediaFormat);
     osEPiReadIo(gCartHandle, 0x3C, &sCartInfo.regionInfo);
 
+    if (sCartInfo.countryCode == '\0') {
+        // Fix-up for region free header
+
+        switch (osTvType) {
+            case OS_TV_NTSC:
+            case OS_TV_MPAL:
+                sCartInfo.countryCode = 'E';
+                break;
+            case OS_TV_PAL:
+                sCartInfo.countryCode = 'P';
+                break;
+            default:
+                PRINTF("z_locale_init: Bad TV Type? (%u)\n", osTvType);
+                LogUtils_HungupThread("../z_locale.c", 118);
+                break;
+        }
+    }
+
     switch (sCartInfo.countryCode) {
         case 'J': // "NTSC-J (Japan)"
             gCurrentRegion = REGION_JP;

--- a/src/code/game.c
+++ b/src/code/game.c
@@ -295,14 +295,25 @@ void GameState_Update(GameState* gameState) {
         gfxCtx->xScale = gViConfigXScale;
         gfxCtx->yScale = gViConfigYScale;
 
-        if (SREG(63) == 5 || (SREG(63) == 2u && osTvType == OS_TV_MPAL)) {
-            gfxCtx->viMode = &osViModeMpalLan1;
-            gfxCtx->yScale = 1.0f;
-        } else {
+        if (SREG(63) == 6 || (SREG(63) == 2u && osTvType == OS_TV_NTSC)) {
             gfxCtx->viMode = &osViModeNtscLan1;
             gfxCtx->yScale = 1.0f;
         }
 
+        if (SREG(63) == 5 || (SREG(63) == 2u && osTvType == OS_TV_MPAL)) {
+            gfxCtx->viMode = &osViModeMpalLan1;
+            gfxCtx->yScale = 1.0f;
+        }
+
+        if (SREG(63) == 4 || (SREG(63) == 2u && osTvType == OS_TV_PAL)) {
+            gfxCtx->viMode = &gCustomViModePal60Lan1;
+            gfxCtx->yScale = 1.0f;
+        }
+
+        if (SREG(63) == 3 || (SREG(63) == 2u && osTvType == OS_TV_PAL)) {
+            gfxCtx->viMode = &gCustomViModePal60Lan1;
+            gfxCtx->yScale = 1.0f;
+        }
     } else {
         gfxCtx->viMode = NULL;
     }

--- a/src/code/z_vimode.c
+++ b/src/code/z_vimode.c
@@ -226,11 +226,7 @@ void ViMode_Init(ViMode* viMode) {
     viMode->upperAdjust = 0;
     viMode->lowerAdjust = 0;
     viMode->viFeatures = OS_VI_DITHER_FILTER_ON | OS_VI_GAMMA_OFF;
-    if (osTvType == OS_TV_PAL) {
-        viMode->tvType = OS_TV_NTSC;
-    } else {
-        viMode->tvType = osTvType;
-    }
+    viMode->tvType = osTvType;
     viMode->fb16Bit = true;
     viMode->modeN = true;
     viMode->antialiasOff = false;

--- a/src/makerom/rom_header.h
+++ b/src/makerom/rom_header.h
@@ -16,6 +16,7 @@
 #define REGION_CODE_PAL      "P"
 #define REGION_CODE_GATEWAY  "G"
 #define REGION_CODE_LODGENET "L"
+#define REGION_CODE_FREE     "\0"
 
 /**
  * Magic value to determine if the ROM is byteswapped.

--- a/src/makerom/rom_header.s
+++ b/src/makerom/rom_header.s
@@ -12,15 +12,12 @@
 
 #ifdef CONSOLE_WIIVC
 /* 0x3B */ MEDIUM(CARTRIDGE_EXPANDABLE)
-#else
-/* 0x3B */ MEDIUM(CARTRIDGE)
-#endif
-
 /* 0x3C */ GAME_ID("ZL")
 /* 0x3E */ REGION(US)
-
-#ifdef CONSOLE_WIIVC
 /* 0x3F */ GAME_REVISION(0)
 #else
+/* 0x3B */ MEDIUM(CARTRIDGE)
+/* 0x3C */ GAME_ID("ZL")
+/* 0x3E */ REGION(FREE)
 /* 0x3F */ GAME_REVISION(15)
 #endif


### PR DESCRIPTION
**PAL60**

This should :tm: improve compatibility with video devices.

Forcing the stock NTSC LAN1 mode on a PAL device seems ok at first, but the timings are significantly out-of-spec leading to spotty compatibility. To quote lidnariq in N64Brew:
> The normal N64 "PAL60" mode is what you get from trying to use the NTSC VI configuration with the PAL VI clock. As a result, the timing is significantly out-of-spec - 2.5% too fast hsync.
> Ideally, if you wanted to support PAL60, you'd use the normal PAL VI configuration, but reduce the total number of scanlines (VI_VSYNC) only.

This change brings the timings more in-spec by doing what lidnariq suggested, adjusting VSYNC and VSTART in the VI Mode. However, I had to keep VSYNC slightly out-of-spec to get true 60Hz: a fully in-spec VSYNC of 525 half-lines would produce retraces that were too slow, only hitting ~19.8fps instead of 20fps. I instead used a VSYNC of 519 half-lines, which deviates from the nominal value by 1.14%. I'm under the impression that this should :tm: still be widely compatible; to quote lidnariq again:
> I generally assume things will hsync to within 2% and vsync to within 5%
> A bunch of real devices (Fairchild Channel F, color Pong-on-a-chips) released in the US used a very-fast 15980Hz hsync (1.6% fast), and the slowest NTSC device I know of is 15536Hz (Casio's PV-1000; 1.3% slow); I never heard of the former being a problem but a number of devices object to the latter.

It would be great if we could get some wider testing organized.

**Region Free**

Additionally, I learned that the Everdrive X7 (and possibly other flashcarts, needs testing) will not lie about the console's TV type if the region byte in the ROM Header was set to 0x00. I've implemented this as `REGION(FREE)` so that we can trust the value of `osTvType`. This also needs checking on wider hardware since I only have an X7 to test with.
